### PR TITLE
fix malformed data in multipart/form-data fields

### DIFF
--- a/core/required/router.js
+++ b/core/required/router.js
@@ -184,7 +184,8 @@ module.exports = (() => {
 
               if (meta.name) {
                 if (!contentType) {
-                  data[meta.name] = content;
+                  let buffer = new Buffer(content, 'binary');
+                  data[meta.name] = buffer.toString();
                 } else {
                   let buffer = new Buffer(content, 'binary');
                   buffer.contentType = contentType;


### PR DESCRIPTION
Simple fields in multipart/form-data requests are malformed. How to reproduce:
```
curl -X POST -H "Cache-Control: no-cache" -H "Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW" -F "title=привет" "http://localhost:3000/v1/test"
```
```
{
  "meta": {
    "total": 1,
    "count": 1,
    "offset": 0,
    "error": null
  },
  "data": [
    {
      "id": 36,
      "title": "Ð¿ÑÐ¸Ð²ÐµÑ",
      "body": null,
      "created_at": "2016-06-21T09:26:46.804Z",
      "updated_at": "2016-06-21T09:26:46.808Z"
    }
  ]
}
```

But we need to get

```
{
  "meta": {
    "total": 1,
    "count": 1,
    "offset": 0,
    "error": null
  },
  "data": [
    {
      "id": 36,
      "title": "привет",
      "body": null,
      "created_at": "2016-06-21T09:26:46.804Z",
      "updated_at": "2016-06-21T09:26:46.808Z"
    }
  ]
}
```

So that PR will fix it.